### PR TITLE
Custom

### DIFF
--- a/application/basilisk/branding/unofficial/branding.nsi
+++ b/application/basilisk/branding/unofficial/branding.nsi
@@ -12,5 +12,5 @@
 !define CompanyName           "Moonchild Productions"
 !define URLInfoAbout          "https://www.basilisk-browser.org"
 !define URLUpdateInfo         "https://www.basilisk-browser.org"
-!define HelpLink              "https://forum.palemoon.org"
+!define HelpLink              "https://msfn.org/board/topic/177125-my-build-of-new-moon-temp-name-aka-pale-moon-fork-targetting-xp/?do=getNewComment"
 !define URLSystemRequirements "https://www.basilisk-browser.org"

--- a/application/basilisk/branding/unofficial/pref/basilisk-branding.js
+++ b/application/basilisk/branding/unofficial/pref/basilisk-branding.js
@@ -19,7 +19,7 @@ pref("startup.homepage_welcome_url", "");
 pref("startup.homepage_welcome_url.additional", "");
 
 // Version release notes
-pref("app.releaseNotesURL", "about:blank");
+pref("app.releaseNotesURL", "https://rtfreesoft.blogspot.com/search/label/serpent");
 
 // Vendor home page
 pref("app.vendorURL", "about:");

--- a/application/palemoon/app/profile/palemoon.js
+++ b/application/palemoon/app/profile/palemoon.js
@@ -924,7 +924,7 @@ pref("browser.zoom.siteSpecific", true);
 pref("browser.zoom.updateBackgroundTabs", true);
 
 // base URL for web-based support pages
-pref("app.support.baseURL", "https://msfn.org/board/topic/177125-my-build-of-new-moon-temp-name-aka-pale-moon-fork-targetting-xp");
+pref("app.support.baseURL", "https://rtfreesoft.blogspot.com/p/browser-help.html#");
 
 // Name of alternate about: page for certificate errors (when undefined, defaults to about:neterror)
 pref("security.alternate_certificate_error_page", "certerror");

--- a/application/palemoon/app/profile/palemoon.js
+++ b/application/palemoon/app/profile/palemoon.js
@@ -79,7 +79,7 @@ pref("browser.getdevtools.url","https://@AM_DOMAIN@/?component=integration&type=
 pref("browser.feedback.url", "https://forum.palemoon.org");
 
 // Help button in slow startup dialog
-pref("browser.slowstartup.help.url", "http://www.palemoon.org/support/slowstartup.shtml");
+pref("browser.slowstartup.help.url", "https://support.mozilla.org/en-US/kb/firefox-takes-long-time-start-up");
 
 // Whether to escape to a content-less page if a user presses "Get me out of here"
 // on a network error page (e.g. cert error)
@@ -924,7 +924,7 @@ pref("browser.zoom.siteSpecific", true);
 pref("browser.zoom.updateBackgroundTabs", true);
 
 // base URL for web-based support pages
-pref("app.support.baseURL", "http://www.palemoon.org/support/");
+pref("app.support.baseURL", "https://msfn.org/board/topic/177125-my-build-of-new-moon-temp-name-aka-pale-moon-fork-targetting-xp");
 
 // Name of alternate about: page for certificate errors (when undefined, defaults to about:neterror)
 pref("security.alternate_certificate_error_page", "certerror");

--- a/application/palemoon/app/profile/palemoon.js
+++ b/application/palemoon/app/profile/palemoon.js
@@ -76,7 +76,7 @@ pref("browser.dictionaries.download.url", "https://@AM_DOMAIN@/dictionaries/");
 pref("browser.getdevtools.url","https://@AM_DOMAIN@/?component=integration&type=external&request=devtools");
 
 // Feedback URL
-pref("browser.feedback.url", "https://forum.palemoon.org");
+pref("browser.feedback.url", "https://msfn.org/board/topic/177125-my-build-of-new-moon-temp-name-aka-pale-moon-fork-targetting-xp/?do=getNewComment");
 
 // Help button in slow startup dialog
 pref("browser.slowstartup.help.url", "https://support.mozilla.org/en-US/kb/firefox-takes-long-time-start-up");

--- a/application/palemoon/branding/unofficial/branding.nsi
+++ b/application/palemoon/branding/unofficial/branding.nsi
@@ -12,5 +12,5 @@
 !define CompanyName           "Moonchild Productions"
 !define URLInfoAbout          "http://www.palemoon.org"
 !define URLUpdateInfo         "http://www.palemoon.org"
-!define HelpLink              "http://www.palemoon.org"
+!define HelpLink              "https://msfn.org/board/topic/177125-my-build-of-new-moon-temp-name-aka-pale-moon-fork-targetting-xp/?do=getNewComment"
 !define URLSystemRequirements "http://www.palemoon.org/download.shtml"

--- a/application/palemoon/branding/unofficial/pref/palemoon-branding.js
+++ b/application/palemoon/branding/unofficial/pref/palemoon-branding.js
@@ -3,8 +3,8 @@
 #include ../../shared/pref/preferences.inc
 #include ../../shared/pref/uaoverrides.inc
 
-pref("startup.homepage_override_url","http://www.palemoon.org/unofficial.shtml");
-pref("app.releaseNotesURL", "http://www.palemoon.org/releasenotes.shtml");
+pref("startup.homepage_override_url","");
+pref("app.releaseNotesURL", "https://rtfreesoft.blogspot.com/search/label/newmoon");
 
 // Updates disabled
 pref("app.update.enabled", false);


### PR DESCRIPTION
I had to add a few more changes to complete the migration of New Moon away from referencing palemoon.org. Three more prefs (app.feedback.url, app.support.baseURL, and browser.slowstartup.help.url) were changed in palemoon.js along with Monday's changes.