### PR TITLE
Point Help / Submit Feedback to MSFN (Serpent)

### DIFF
--- a/application/basilisk/app/profile/basilisk.js
+++ b/application/basilisk/app/profile/basilisk.js
@@ -877,9 +877,6 @@ pref("app.support.baseURL", "https://support.mozilla.org/1/firefox/%VERSION%/%OS
 // a11y conflicts with e10s support page
 pref("app.support.e10sAccessibilityUrl", "https://support.mozilla.org/1/firefox/%VERSION%/%OS%/%LOCALE%/accessibility-ppt");
 
-// base url for web-based feedback pages
-pref("app.feedback.baseURL", "https://forum.palemoon.org/viewforum.php?f=61");
-
 // Name of alternate about: page for certificate errors (when undefined, defaults to about:neterror)
 pref("security.alternate_certificate_error_page", "certerror");
 

--- a/application/basilisk/branding/official/pref/basilisk-branding.js
+++ b/application/basilisk/branding/official/pref/basilisk-branding.js
@@ -25,6 +25,9 @@ pref("startup.homepage_welcome_url.additional", "");
 // Version release notes
 pref("app.releaseNotesURL", "http://@BRANDING_SITEURL@/@BRANDING_RELNOTESPATH@");
 
+// base url for web-based feedback pages
+pref("app.feedback.baseURL", "https://forum.palemoon.org/viewforum.php?f=61");
+
 // Vendor home page
 pref("app.vendorURL", "http://@BRANDING_SITEURL@/");
 

--- a/application/basilisk/branding/unofficial/pref/basilisk-branding.js
+++ b/application/basilisk/branding/unofficial/pref/basilisk-branding.js
@@ -21,6 +21,9 @@ pref("startup.homepage_welcome_url.additional", "");
 // Version release notes
 pref("app.releaseNotesURL", "https://rtfreesoft.blogspot.com/search/label/serpent");
 
+// base url for web-based feedback pages
+pref("app.feedback.baseURL", "https://msfn.org/board/topic/177125-my-build-of-new-moon-temp-name-aka-pale-moon-fork-targetting-xp/?do=getNewComment");
+
 // Vendor home page
 pref("app.vendorURL", "about:");
 


### PR DESCRIPTION
This is the same change I made to New Moon last week, but missed in Serpent, pointing Help / Submit Feedback to the MSFN thread for New Moon & Serpent vs. forum.palemoon.org, so users can leave feedback where Roytam1 et al. can see it and respond.