### PR TITLE
Fix background image URL for 'Serpent' wordmark

### DIFF
--- a/application/basilisk/base/content/aboutDialog.css
+++ b/application/basilisk/base/content/aboutDialog.css
@@ -11,7 +11,7 @@
 }
 
 #rightBox {
-  background-image: url("chrome://branding/content/about-wordmark.png");
+  background-image: url("chrome://branding/content/about-wordmark.svg");
   background-repeat: no-repeat;
   /* padding-top creates room for the wordmark */
   padding-top: 38px;


### PR DESCRIPTION
Wordmark 'Serpent' shows up in Serpent 55 about box, but doesn't show up in Serpent 52 due to incorrect extension in URL. Changing extension from '.png' (wrong) to '.svg' (correct) will fix this.