### PR TITLE
The first column of a <tree> element was always missing from the …

### DIFF
--- a/toolkit/content/widgets/tree.xml
+++ b/toolkit/content/widgets/tree.xml
@@ -1498,7 +1498,7 @@
 
             var tree = this.parentNode.parentNode;
             if (tree.columns)
-              for (var currCol = tree.columns.getFirstColumn(); currCol = currCol.getNext(); ) {
+              for (var currCol = tree.columns.getFirstColumn(); currCol; currCol = currCol.getNext()) {
                 // Construct an entry for each column in the row, unless
                 // it is not being shown.
                 var currElement = currCol.element;


### PR DESCRIPTION
… column picker's drop-down menu

(I've created a PR for this bug in the palemoon.org repository too.)